### PR TITLE
修复BaseParams 没有 cancel option 的问题

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -103,6 +103,8 @@ declare namespace wx {
     success?(...args: any[]): void;
     /** 接口调用失败的回调函数 */
     fail?(...args: any[]): void;
+    /** 接口取消调用的回调函数 */
+    cancel?(...args: any[]): void;
     /** 接口调用结束的回调函数（调用成功、失败都会执行） */
     complete?(...args: any[]): void;
   }


### PR DESCRIPTION
用户取消时："xxx:cancel"，其中xxx为调用的接口名

