### PR TITLE
jsApiList | openTagList 设置可选参数

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -92,8 +92,8 @@ declare namespace wx {
     timestamp: number; // 必填，生成签名的时间戳
     nonceStr: string; // 必填，生成签名的随机串
     signature: string; // 必填，签名，见附录1
-    jsApiList: jsApiList; // 必填，需要使用的JS接口列表，所有JS接口列表见附录2
-    openTagList: openTagList;
+    jsApiList?: jsApiList; // 必填，需要使用的JS接口列表，所有JS接口列表见附录2
+    openTagList?: openTagList;
   }): void;
 
   interface Resouce {


### PR DESCRIPTION
用户可选`jsApiList` | `openTagList`,进行注册，目前2个必选,但是项目中用不到`jsApiList` | `openTagList`